### PR TITLE
Update RedFishCollector to match right way to get power from latest datamodel of redfish

### DIFF
--- a/server-collector/utils/collector.py
+++ b/server-collector/utils/collector.py
@@ -369,7 +369,12 @@ class SensorsCollector(Thread):
                     )
                     measurements = self.get_sensors()
                     self.log.debug(
-                        "[%s]: MESAUREMENT=%s",
+                        "[%s]: collect processing time is %d ms",
+                        self.name,
+                        (int(time.time())*1000000000 - data_time)//1000000
+                    )
+                    self.log.debug(
+                        "[%s]: MEASUREMENT=%s",
                         self.name,
                         measurements
                     )


### PR DESCRIPTION
Redfish protocol uses datamodel that offers several ways amon versions and freedom to provider to provider power:

power block is now deprecated till 2020 and EnvironmentMetrics is the standard way to get power
But in order to cope with new BMC updated servers, and still be able to get power we need to still support power block

Moreover PowerControl subbock is a list of items in which only one refers to server and integrating "bug" from BMC SW old implementation, several ways exist to get the right element and the standard one is not always available.

This update integrate all these elements 